### PR TITLE
[MT-1750] Update Facebook SDK (#12)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace = "com.tealium.example"
-    compileSdkVersion 36
+    compileSdkVersion 35
 
     defaultConfig {
         applicationId = "com.tealium.example"
         minSdkVersion 21
-        targetSdkVersion 36
+        targetSdkVersion 35
         versionCode = 1
         versionName = "1.0.0"
         

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace = "com.tealium.example"
-    compileSdkVersion 33
+    compileSdkVersion 35
 
     defaultConfig {
         applicationId = "com.tealium.example"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 35
         versionCode = 1
         versionName = "1.0.0"
         
@@ -29,12 +29,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     buildFeatures {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,16 +2,19 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
-    buildToolsVersion "30.0.3"
+    namespace = "com.tealium.example"
+    compileSdkVersion 36
+
     defaultConfig {
-        applicationId "com.tealium.example"
+        applicationId = "com.tealium.example"
         minSdkVersion 21
-        targetSdkVersion 31
-        versionCode 1
-        versionName "1.0.0"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        targetSdkVersion 36
+        versionCode = 1
+        versionName = "1.0.0"
+        
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
+    
     buildTypes {
         debug {
             buildConfigField "String", "TEALIUM_VERSION", "\"$tealium_version\""
@@ -26,16 +29,17 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_21.toString()
     }
 
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
 }
 
@@ -43,14 +47,14 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     debugImplementation project(path: ':facebook')
     releaseImplementation "com.tealium.remotecommands:facebook:$tealium_facebook_version"
-    implementation "com.tealium:kotlin-remotecommand-dispatcher:1.2.0"
-    implementation "com.tealium:kotlin-tagmanagement-dispatcher:1.2.0"
-    implementation "com.tealium:kotlin-lifecycle:1.1.1"
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation "com.tealium:kotlin-remotecommand-dispatcher:1.5.2"
+    implementation "com.tealium:kotlin-tagmanagement-dispatcher:1.2.5"
+    implementation "com.tealium:kotlin-lifecycle:1.2.2"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.core:core-ktx:1.16.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test:runner:1.6.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,12 +29,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
+        jvmTarget = JavaVersion.VERSION_11
     }
 
     buildFeatures {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace = "com.tealium.example"
-    compileSdkVersion 35
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId = "com.tealium.example"
         minSdkVersion 21
-        targetSdkVersion 35
+        targetSdkVersion 33
         versionCode = 1
         versionName = "1.0.0"
         
@@ -29,12 +29,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_21
-        targetCompatibility JavaVersion.VERSION_21
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21.toString()
+        jvmTarget = JavaVersion.VERSION_11
     }
 
     buildFeatures {
@@ -51,9 +51,8 @@ dependencies {
     implementation "com.tealium:kotlin-tagmanagement-dispatcher:1.2.5"
     implementation "com.tealium:kotlin-lifecycle:1.2.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation 'androidx.core:core-ktx:1.16.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test:runner:1.6.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.tealium.example">
+          xmlns:tools="http://schemas.android.com/tools">
 
     <application
             android:name=".App"
@@ -12,6 +12,8 @@
             android:theme="@style/AppTheme">
         <meta-data android:name="com.facebook.sdk.ApplicationId"
                    android:value="@string/facebook_app_id"/>
+        <meta-data android:name="com.facebook.sdk.ClientToken"
+                   android:value="@string/facebook_client_token"/>
         <activity android:name="com.tealium.example.MainActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/assets/facebook.json
+++ b/app/src/main/assets/facebook.json
@@ -1,6 +1,7 @@
 {
   "config": {
       "applicationid": "407125680222876",
+      "clienttoken": "myclienttoken",
       "accesstoken": "mytoken",
       "userid": "myuser",
       "auto_log_events_enabled": true,

--- a/app/src/main/java/com/tealium/example/MainActivity.kt
+++ b/app/src/main/java/com/tealium/example/MainActivity.kt
@@ -9,7 +9,7 @@ import com.tealium.example.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
 
-    lateinit var binding: ActivityMainBinding
+    private lateinit var binding: ActivityMainBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -61,7 +61,7 @@ class MainActivity : AppCompatActivity() {
     private fun setUserId() {
         TealiumHelper.trackEvent(
             "setuserid", mutableMapOf<String, Any>(
-                "customer_id" to User.customerId
+                "customer_id" to User.CUSTOMER_ID
             )
         )
     }
@@ -94,8 +94,8 @@ class MainActivity : AppCompatActivity() {
     private fun addToCart() {
         TealiumHelper.trackEvent(
             "addtocart", mutableMapOf<String, Any>(
-                "product_id" to Product.productId,
-                "product_unit_price" to Product.productPrice
+                "product_id" to Product.PRODUCT_ID,
+                "product_unit_price" to Product.PRODUCT_PRICE
             )
         )
     }
@@ -124,10 +124,10 @@ object Purchase {
 }
 
 object User {
-    val customerId = "cust123"
+    const val CUSTOMER_ID = "customerid123"
     val profile = mutableMapOf<String, String>(
         "customer_email" to "test@test.com",
-        "customer_id" to customerId,
+        "customer_id" to CUSTOMER_ID,
         "customer_first_name" to "John",
         "customer_last_name" to "Doe",
         "customer_phone" to "858-555-6666",
@@ -140,10 +140,10 @@ object User {
 }
 
 object Product {
-    val productId = "abc123"
-    val productPrice = 19.99
+    const val PRODUCT_ID = "abc123"
+    const val PRODUCT_PRICE = 19.99
     val info = mutableMapOf<String, Any>(
-        "product_id" to productId,
+        "product_id" to PRODUCT_ID,
         "product_availability" to 1,
         "product_condition" to 2,
         "product_description" to "really cool",
@@ -152,7 +152,7 @@ object Product {
         "product_name" to "some cool product",
         "product_gtin" to "ASDF235562SDFSDF",
         "product_brand" to "awesome brand",
-        "product_unit_price" to productPrice,
+        "product_unit_price" to PRODUCT_PRICE,
         "currency" to "USD",
         "online_store_id" to "ABC234SDF",
         "bulk_discount" to "15"

--- a/app/src/main/java/com/tealium/example/TealiumHelper.kt
+++ b/app/src/main/java/com/tealium/example/TealiumHelper.kt
@@ -11,9 +11,7 @@ import com.tealium.remotecommanddispatcher.remoteCommands
 import com.tealium.remotecommands.facebook.FacebookRemoteCommand
 
 object TealiumHelper {
-    private const val TAG = "TealiumHelper"
-
-    const val TEALIUM_MAIN = "main"
+    private const val TEALIUM_MAIN = "main"
 
     @JvmStatic
     fun initialize(application: Application) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,8 @@
 <resources>
     <string name="app_name">TealiumFacebook</string>
     <string name="facebook_app_id">YOUR_FACEBOOK_APP_ID</string>
-    <string name="fb_login_protocol_scheme">YOUR_FACEBOOK_LOGIN</string>
+    <string name="facebook_client_token">YOUR_FACEBOOK_CLIENT_TOKEN</string>
+    <string name="fb_login_protocol_scheme">fbYOUR_FACEBOOK_APP_ID</string>
     <string name="purchase">Purchase</string>
     <string name="set_user">Set User</string>
     <string name="set_user_id">Set User Id</string>

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext.kotlin_version = '1.6.0'
     ext.mockk_version = '1.12.8'
-    ext.facebook_version = '[7,16)'
+    ext.facebook_version = '18.0.3'
     ext.tealium_version = '1.0.0'
     ext.tealium_facebook_version = '2.0.2'
     repositories {
@@ -30,6 +30,6 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '2.1.0'
+    ext.kotlin_version = '1.9.23'
     ext.mockk_version = '1.13.9'
-    ext.facebook_version = '18.0.3'
+    ext.facebook_version = '[7,19)'
     ext.tealium_version = '1.0.0'
-    ext.tealium_facebook_version = '2.0.3'
+    ext.tealium_facebook_version = '3.0.0'
     repositories {
         google()
         mavenCentral()
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.10.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.6.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.mockk_version = '1.13.9'
     ext.facebook_version = '18.0.3'
     ext.tealium_version = '1.0.0'
-    ext.tealium_facebook_version = '2.0.2'
+    ext.tealium_facebook_version = '2.0.3'
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.0'
+    ext.kotlin_version = '2.1.0'
     ext.mockk_version = '1.12.8'
     ext.facebook_version = '18.0.3'
     ext.tealium_version = '1.0.0'
@@ -12,7 +12,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.android.tools.build:gradle:8.10.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -31,5 +31,5 @@ allprojects {
 }
 
 tasks.register('clean', Delete) {
-    delete rootProject.buildDir
+    delete layout.buildDirectory
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = '2.1.0'
-    ext.mockk_version = '1.12.8'
+    ext.mockk_version = '1.13.9'
     ext.facebook_version = '18.0.3'
     ext.tealium_version = '1.0.0'
     ext.tealium_facebook_version = '2.0.2'

--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -1,22 +1,20 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven-publish'
 
 android {
-    compileSdkVersion 31
-    buildToolsVersion "30.0.3"
+    namespace = "com.tealium.remotecommands.facebook"
+    compileSdkVersion 36
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 31
-        versionCode 1
-        versionName "$tealium_facebook_version"
-        buildConfigField 'String', "TEALIUM_FACEBOOK_VERSION", "\"$tealium_facebook_version\""
+        targetSdkVersion 36
+        versionCode = 1
+        versionName = "$tealium_facebook_version"
+        buildConfigField "String", "TEALIUM_FACEBOOK_VERSION", "\"$tealium_facebook_version\""
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles 'consumer-rules.pro'
-
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles = ['consumer-rules.pro']
     }
 
     buildTypes {
@@ -31,52 +29,63 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
+        jvmTarget = JavaVersion.VERSION_21.toString()
+    }
+
+    buildFeatures {
+        buildConfig = true
+    }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
     }
 }
 
-afterEvaluate {
-    publishing {
-        publications {
-            mavenJava(MavenPublication) {
+publishing {
+    publications {
+        release(MavenPublication) {
+            groupId = 'com.tealium.remotecommands'
+            artifactId = 'facebook'
+            version = "$tealium_facebook_version"
+            afterEvaluate {
                 from components.release
-                groupId 'com.tealium.remotecommands'
-                artifactId 'facebook'
-                version "$tealium_facebook_version"
             }
         }
-
-        repositories {
-    //        maven {
-    //            url "s3://maven.tealiumiq.com/android/releases/"
-    //            credentials(AwsCredentials) {
-    //                accessKey AWS_ACCESS_KEY
-    //                secretKey AWS_SECRET_KEY
-    //                sessionToken AWS_SESSION_TOKEN
-    //            }
-    //        }
-        }
     }
+    // repositories {
+    //     maven {
+    //         url "s3://maven.tealiumiq.com/android/releases/"
+    //         credentials(AwsCredentials) {
+    //             accessKey AWS_ACCESS_KEY
+    //             secretKey AWS_SECRET_KEY
+    //             sessionToken AWS_SESSION_TOKEN
+    //         }
+    //     }
+    // }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     api "com.facebook.android:facebook-android-sdk:$facebook_version"
-    implementation 'com.tealium:remotecommands:1.0.1'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'com.tealium:remotecommands:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation "org.robolectric:robolectric:4.8"
+    testImplementation "org.robolectric:robolectric:4.14.1"
     testImplementation "io.mockk:mockk:$mockk_version"
-    androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    implementation "androidx.core:core-ktx:1.7.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    androidTestImplementation 'androidx.test:runner:1.6.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    implementation "androidx.core:core-ktx:1.16.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
+
 repositories {
     mavenCentral()
 }

--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'maven-publish'
 
 android {
     namespace = "com.tealium.remotecommands.facebook"
-    compileSdkVersion 33
+    compileSdk = 35
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 33
+        minSdk = 21
+        targetSdk = 35
         versionCode = 1
         versionName = "$tealium_facebook_version"
         buildConfigField "String", "TEALIUM_FACEBOOK_VERSION", "\"$tealium_facebook_version\""
@@ -29,12 +29,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     buildFeatures {

--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -29,12 +29,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
+        jvmTarget = JavaVersion.VERSION_11
     }
 
     buildFeatures {

--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'maven-publish'
 
 android {
     namespace = "com.tealium.remotecommands.facebook"
-    compileSdkVersion 36
+    compileSdkVersion 35
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 36
+        targetSdkVersion 35
         versionCode = 1
         versionName = "$tealium_facebook_version"
         buildConfigField "String", "TEALIUM_FACEBOOK_VERSION", "\"$tealium_facebook_version\""
@@ -45,6 +45,12 @@ android {
         singleVariant("release") {
             withSourcesJar()
             withJavadocJar()
+        }
+    }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
         }
     }
 }

--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'maven-publish'
 
 android {
     namespace = "com.tealium.remotecommands.facebook"
-    compileSdkVersion 35
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 35
+        targetSdkVersion 33
         versionCode = 1
         versionName = "$tealium_facebook_version"
         buildConfigField "String", "TEALIUM_FACEBOOK_VERSION", "\"$tealium_facebook_version\""
@@ -29,12 +29,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_21
-        targetCompatibility JavaVersion.VERSION_21
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_21.toString()
+        jvmTarget = JavaVersion.VERSION_11
     }
 
     buildFeatures {
@@ -81,15 +81,12 @@ publishing {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     api "com.facebook.android:facebook-android-sdk:$facebook_version"
-    implementation 'com.tealium:remotecommands:1.0.2'
-    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'com.tealium:remotecommands:1.0.3'
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.robolectric:robolectric:4.14.1"
     testImplementation "io.mockk:mockk:$mockk_version"
     androidTestImplementation 'androidx.test:runner:1.6.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-    implementation "androidx.core:core-ktx:1.16.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 repositories {

--- a/facebook/src/main/AndroidManifest.xml
+++ b/facebook/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.tealium.remotecommands.facebook">
+          xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/facebook/src/main/AndroidManifest.xml
+++ b/facebook/src/main/AndroidManifest.xml
@@ -3,8 +3,10 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <meta-data android:name="com.facebook.sdk.AutoLogAppEventsEnabled"
-               android:value="false"/>
-    <meta-data android:name="com.facebook.sdk.AutoInitEnabled"
-               android:value="false"/>
+    <application>
+        <meta-data android:name="com.facebook.sdk.AutoLogAppEventsEnabled"
+                   android:value="false"/>
+        <meta-data android:name="com.facebook.sdk.AutoInitEnabled"
+                   android:value="false"/>
+    </application>
 </manifest>

--- a/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookCommand.kt
+++ b/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookCommand.kt
@@ -7,7 +7,7 @@ import java.util.*
 
 interface FacebookCommand {
     // com.tealium.remotecommands.facebook.Initialize
-    fun initialize(applicationId: String?, debugEnabled: Boolean?)
+    fun initialize(applicationId: String?, clientToken: String?, debugEnabled: Boolean?)
     fun enableAutoLogAppEvents(enable: Boolean)
     fun enableAutoInitialize(enable: Boolean)
     fun enableAdvertiserIDCollection(enable: Boolean)

--- a/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookCommand.kt
+++ b/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookCommand.kt
@@ -6,7 +6,7 @@ import java.math.BigDecimal
 import java.util.*
 
 interface FacebookCommand {
-    // Initialize
+    // com.tealium.remotecommands.facebook.Initialize
     fun initialize(applicationId: String?, debugEnabled: Boolean?)
     fun enableAutoLogAppEvents(enable: Boolean)
     fun enableAutoInitialize(enable: Boolean)
@@ -34,7 +34,7 @@ interface FacebookCommand {
     fun setUserID(userId: String)
     fun clearUserData()
     fun clearUserID()
-    // Product
+    // com.tealium.remotecommands.facebook.Product
     fun logProductItem(
         itemID: String,
         availability: AppEventsLogger.ProductAvailability?,
@@ -50,9 +50,9 @@ interface FacebookCommand {
         brand: String,
         parameters: Bundle
     )
-    // Flush Events
+    // com.tealium.remotecommands.facebook.Flush Events
     fun setFlushBehavior(flushValue: String)
     fun flush()
-    // Push
+    // com.tealium.remotecommands.facebook.Push
     fun setPushNotificationsRegistrationId(registrationId: String)
 }

--- a/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookCommand.kt
+++ b/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookCommand.kt
@@ -6,7 +6,7 @@ import java.math.BigDecimal
 import java.util.*
 
 interface FacebookCommand {
-    // com.tealium.remotecommands.facebook.Initialize
+    // Initialize
     fun initialize(applicationId: String?, clientToken: String?, debugEnabled: Boolean?)
     fun enableAutoLogAppEvents(enable: Boolean)
     fun enableAutoInitialize(enable: Boolean)
@@ -34,7 +34,7 @@ interface FacebookCommand {
     fun setUserID(userId: String)
     fun clearUserData()
     fun clearUserID()
-    // com.tealium.remotecommands.facebook.Product
+    // Product
     fun logProductItem(
         itemID: String,
         availability: AppEventsLogger.ProductAvailability?,
@@ -50,9 +50,9 @@ interface FacebookCommand {
         brand: String,
         parameters: Bundle
     )
-    // com.tealium.remotecommands.facebook.Flush Events
+    // Flush Events
     fun setFlushBehavior(flushValue: String)
     fun flush()
-    // com.tealium.remotecommands.facebook.Push
+    // Push
     fun setPushNotificationsRegistrationId(registrationId: String)
 }

--- a/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookConstants.kt
+++ b/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookConstants.kt
@@ -1,5 +1,7 @@
 @file:JvmName("FacebookConstants")
 
+package com.tealium.remotecommands.facebook
+
 import com.facebook.appevents.AppEventsConstants
 
 object Commands {

--- a/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookConstants.kt
+++ b/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookConstants.kt
@@ -244,5 +244,6 @@ object Advertiser {
 
 object Initialize {
     const val APPLICATION_ID = "applicationid"
+    const val CLIENT_TOKEN = "clienttoken"
     const val DEBUG_ENABLED = "debug"
 }

--- a/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookInstance.kt
+++ b/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookInstance.kt
@@ -1,6 +1,5 @@
 package com.tealium.remotecommands.facebook
 
-import Flush
 import android.app.Application
 import android.os.Bundle
 import com.facebook.FacebookSdk
@@ -10,12 +9,12 @@ import java.math.BigDecimal
 import java.util.*
 
 class FacebookInstance(
-    val application: Application,
+    private val application: Application,
     applicationId: String?,
     debugEnabled: Boolean?
 ) : FacebookCommand {
 
-    lateinit var logger: AppEventsLogger
+    private lateinit var logger: AppEventsLogger
 
     init {
         initialize(applicationId, debugEnabled)

--- a/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookInstance.kt
+++ b/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookInstance.kt
@@ -10,9 +10,9 @@ import java.util.*
 
 class FacebookInstance(
     private val application: Application,
-    applicationId: String?,
+    applicationId: String? = null,
     clientToken: String? = null,
-    debugEnabled: Boolean?
+    debugEnabled: Boolean? = null
 ) : FacebookCommand {
 
     private lateinit var logger: AppEventsLogger

--- a/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookInstance.kt
+++ b/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookInstance.kt
@@ -11,18 +11,22 @@ import java.util.*
 class FacebookInstance(
     private val application: Application,
     applicationId: String?,
+    clientToken: String? = null,
     debugEnabled: Boolean?
 ) : FacebookCommand {
 
     private lateinit var logger: AppEventsLogger
 
     init {
-        initialize(applicationId, debugEnabled)
+        initialize(applicationId, clientToken, debugEnabled)
     }
 
-    override fun initialize(applicationId: String?, debugEnabled: Boolean?) {
+    override fun initialize(applicationId: String?, clientToken: String?, debugEnabled: Boolean?) {
         applicationId?.let { appId ->
             FacebookSdk.setApplicationId(applicationId)
+            clientToken?.let { token ->
+                FacebookSdk.setClientToken(token)
+            }
             FacebookSdk.fullyInitialize()
             debugEnabled?.let {
                 FacebookSdk.setIsDebugEnabled(it)

--- a/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookRemoteCommand.kt
+++ b/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookRemoteCommand.kt
@@ -23,25 +23,22 @@ class FacebookRemoteCommand
  */
 @JvmOverloads
 constructor(
-    application: Application? = null,
+    application: Application,
     commandId: String = DEFAULT_COMMAND_ID,
     description: String = DEFAULT_COMMAND_DESCRIPTION,
     facebookApplicationId: String? = null,
     facebookClientToken: String? = null,
     debugEnabled: Boolean? = null
 ) : RemoteCommand(commandId, description, BuildConfig.TEALIUM_FACEBOOK_VERSION) {
-    
-    init {
-        application?.let { app ->
-            this.application = app
-            if (facebookApplicationId != null && facebookClientToken != null) {
-                facebookInstance = FacebookInstance(app, facebookApplicationId, facebookClientToken, debugEnabled)
-            }
-        }
-    }
 
     private lateinit var application: Application
     private lateinit var facebookInstance: FacebookCommand
+
+    init {
+        if (facebookApplicationId != null && facebookClientToken != null) {
+            facebookInstance = FacebookInstance(application, facebookApplicationId, facebookClientToken, debugEnabled)
+        }
+    }
 
     companion object {
         const val DEFAULT_COMMAND_ID = "facebook"

--- a/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookRemoteCommand.kt
+++ b/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookRemoteCommand.kt
@@ -11,27 +11,39 @@ import java.math.BigDecimal
 import java.util.*
 import kotlin.jvm.Throws
 
-class FacebookRemoteCommand
-/**
- * Constructs a RemoteCommand that integrates with the Facebook App Events SDK to allow Facebook API calls to be implemented through Tealium.
- */
-@JvmOverloads constructor(
-    application: Application? = null,
-    commandId: String = DEFAULT_COMMAND_ID,
-    description: String = DEFAULT_COMMAND_DESCRIPTION,
-    facebookApplicationId: String? = null,
-    debugEnabled: Boolean? = null
-) : RemoteCommand(commandId, description, BuildConfig.TEALIUM_FACEBOOK_VERSION) {
+class FacebookRemoteCommand : RemoteCommand {
 
     private lateinit var facebookInstance: FacebookCommand
     private var application: Application? = null
 
-    init {
+    /**
+     * Constructs a RemoteCommand that integrates with the Facebook App Events SDK to allow Facebook API calls to be implemented through Tealium.
+     */
+    @JvmOverloads
+    constructor(
+        application: Application? = null,
+        commandId: String = DEFAULT_COMMAND_ID,
+        description: String = DEFAULT_COMMAND_DESCRIPTION,
+        facebookApplicationId: String? = null,
+        debugEnabled: Boolean? = null
+    ) : super(commandId, description, BuildConfig.TEALIUM_FACEBOOK_VERSION) {
         application?.let { app ->
             this.application = app
             facebookApplicationId?.let {
                 facebookInstance = FacebookInstance(app, it, debugEnabled)
             }
+        }
+    }
+
+    @JvmOverloads
+    constructor(
+        autoInit: Boolean,
+        application: Application? = null,
+        commandId: String = DEFAULT_COMMAND_ID,
+        description: String = DEFAULT_COMMAND_DESCRIPTION
+    ) : super(commandId, description, BuildConfig.TEALIUM_FACEBOOK_VERSION) {
+        application?.let {
+            this.application = it
         }
     }
 

--- a/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookRemoteCommand.kt
+++ b/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookRemoteCommand.kt
@@ -24,11 +24,11 @@ class FacebookRemoteCommand
 @JvmOverloads
 constructor(
     application: Application,
-    commandId: String = DEFAULT_COMMAND_ID,
-    description: String = DEFAULT_COMMAND_DESCRIPTION,
     facebookApplicationId: String? = null,
     facebookClientToken: String? = null,
-    debugEnabled: Boolean? = null
+    debugEnabled: Boolean? = null,
+    commandId: String = DEFAULT_COMMAND_ID,
+    description: String = DEFAULT_COMMAND_DESCRIPTION,
 ) : RemoteCommand(commandId, description, BuildConfig.TEALIUM_FACEBOOK_VERSION) {
 
     private lateinit var application: Application

--- a/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookRemoteCommand.kt
+++ b/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookRemoteCommand.kt
@@ -16,23 +16,12 @@ class FacebookRemoteCommand
  * Constructs a RemoteCommand that integrates with the Facebook App Events SDK to allow Facebook API calls to be implemented through Tealium.
  */
 constructor(
-    application: Application,
+    private val application: Application,
     commandId: String = DEFAULT_COMMAND_ID,
     description: String = DEFAULT_COMMAND_DESCRIPTION,
-    facebookApplicationId: String? = null,
-    facebookClientToken: String? = null,
-    debugEnabled: Boolean? = null
 ) : RemoteCommand(commandId, description, BuildConfig.TEALIUM_FACEBOOK_VERSION) {
 
     private lateinit var facebookInstance: FacebookCommand
-    private val application: Application
-
-    init {
-        this.application = application
-        facebookApplicationId?.let {
-            facebookInstance = FacebookInstance(application, it, facebookClientToken, debugEnabled)
-        }
-    }
 
     companion object {
         const val DEFAULT_COMMAND_ID = "facebook"

--- a/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookRemoteCommand.kt
+++ b/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookRemoteCommand.kt
@@ -11,39 +11,28 @@ import java.math.BigDecimal
 import java.util.*
 import kotlin.jvm.Throws
 
-class FacebookRemoteCommand : RemoteCommand {
+class FacebookRemoteCommand
+/**
+ * Constructs a RemoteCommand that integrates with the Facebook App Events SDK to allow Facebook API calls to be implemented through Tealium.
+ */
+constructor(
+    application: Application? = null,
+    commandId: String = DEFAULT_COMMAND_ID,
+    description: String = DEFAULT_COMMAND_DESCRIPTION,
+    facebookApplicationId: String? = null,
+    facebookClientToken: String? = null,
+    debugEnabled: Boolean? = null
+) : RemoteCommand(commandId, description, BuildConfig.TEALIUM_FACEBOOK_VERSION) {
 
     private lateinit var facebookInstance: FacebookCommand
     private var application: Application? = null
 
-    /**
-     * Constructs a RemoteCommand that integrates with the Facebook App Events SDK to allow Facebook API calls to be implemented through Tealium.
-     */
-    @JvmOverloads
-    constructor(
-        application: Application? = null,
-        commandId: String = DEFAULT_COMMAND_ID,
-        description: String = DEFAULT_COMMAND_DESCRIPTION,
-        facebookApplicationId: String? = null,
-        debugEnabled: Boolean? = null
-    ) : super(commandId, description, BuildConfig.TEALIUM_FACEBOOK_VERSION) {
+    init {
         application?.let { app ->
             this.application = app
             facebookApplicationId?.let {
-                facebookInstance = FacebookInstance(app, it, debugEnabled)
+                facebookInstance = FacebookInstance(app, it, facebookClientToken, debugEnabled)
             }
-        }
-    }
-
-    @JvmOverloads
-    constructor(
-        autoInit: Boolean,
-        application: Application? = null,
-        commandId: String = DEFAULT_COMMAND_ID,
-        description: String = DEFAULT_COMMAND_DESCRIPTION
-    ) : super(commandId, description, BuildConfig.TEALIUM_FACEBOOK_VERSION) {
-        application?.let {
-            this.application = it
         }
     }
 
@@ -138,6 +127,10 @@ class FacebookRemoteCommand : RemoteCommand {
                         if (payload.optString(Initialize.APPLICATION_ID).isNotBlank()) payload.optString(
                             Initialize.APPLICATION_ID
                         ) else null
+                    val clientToken =
+                        if (payload.optString(Initialize.CLIENT_TOKEN).isNotBlank()) payload.optString(
+                            Initialize.CLIENT_TOKEN
+                        ) else null
                     val debugEnabled = if (payload.optString(Initialize.DEBUG_ENABLED).isNotBlank()) payload.optBoolean(
                         Initialize.DEBUG_ENABLED
                     ) else null
@@ -147,6 +140,7 @@ class FacebookRemoteCommand : RemoteCommand {
                                 FacebookInstance(
                                     appContext,
                                     appId,
+                                    clientToken,
                                     debugEnabled
                                 )
                         } ?: run {

--- a/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookRemoteCommand.kt
+++ b/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookRemoteCommand.kt
@@ -1,17 +1,6 @@
 package com.tealium.remotecommands.facebook
 
-import Advertiser
-import AutoInit
-import AutoLog
-import Commands
-import Event
-import Event.VALUE_TO_SUM
-import Flush
-import Product
-import ProductItemParameters
-import Purchase
-import Push
-import User
+import com.tealium.remotecommands.facebook.Event.VALUE_TO_SUM
 import android.app.Application
 import android.os.Bundle
 import android.util.Log
@@ -22,24 +11,22 @@ import java.math.BigDecimal
 import java.util.*
 import kotlin.jvm.Throws
 
-class FacebookRemoteCommand : RemoteCommand {
+class FacebookRemoteCommand
+/**
+ * Constructs a RemoteCommand that integrates with the Facebook App Events SDK to allow Facebook API calls to be implemented through Tealium.
+ */
+@JvmOverloads constructor(
+    application: Application? = null,
+    commandId: String = DEFAULT_COMMAND_ID,
+    description: String = DEFAULT_COMMAND_DESCRIPTION,
+    facebookApplicationId: String? = null,
+    debugEnabled: Boolean? = null
+) : RemoteCommand(commandId, description, BuildConfig.TEALIUM_FACEBOOK_VERSION) {
 
-    private val TAG = this::class.java.simpleName
+    private lateinit var facebookInstance: FacebookCommand
+    private var application: Application? = null
 
-    lateinit var facebookInstance: FacebookCommand
-    var application: Application? = null
-
-    /**
-     * Constructs a RemoteCommand that integrates with the Facebook App Events SDK to allow Facebook API calls to be implemented through Tealium.
-     */
-    @JvmOverloads
-    constructor(
-        application: Application? = null,
-        commandId: String = DEFAULT_COMMAND_ID,
-        description: String = DEFAULT_COMMAND_DESCRIPTION,
-        facebookApplicationId: String? = null,
-        debugEnabled: Boolean? = null
-    ) : super(commandId, description, BuildConfig.TEALIUM_FACEBOOK_VERSION) {
+    init {
         application?.let { app ->
             this.application = app
             facebookApplicationId?.let {
@@ -48,22 +35,11 @@ class FacebookRemoteCommand : RemoteCommand {
         }
     }
 
-    @JvmOverloads
-    constructor(
-        autoInit: Boolean,
-        application: Application? = null,
-        commandId: String = DEFAULT_COMMAND_ID,
-        description: String = DEFAULT_COMMAND_DESCRIPTION
-    ) : super(commandId, description, BuildConfig.TEALIUM_FACEBOOK_VERSION) {
-        application?.let {
-            this.application = it
-        }
-    }
-
     companion object {
         const val DEFAULT_COMMAND_ID = "facebook"
         const val DEFAULT_COMMAND_DESCRIPTION = "Tealium-Facebook Remote Command"
         const val REQUIRED_KEY = "key does not exist in the payload."
+        const val TAG = "FacebookRemoteCommand"
 
         /**
          * Maps a JSON object to a Bundle. Does not support nested objects.
@@ -74,8 +50,7 @@ class FacebookRemoteCommand : RemoteCommand {
         fun mapJsonToBundle(json: JSONObject?, bundle: Bundle) {
             json?.let {
                 it.keys().forEach { key ->
-                    val value = json[key]
-                    when (value) {
+                    when (val value = json[key]) {
                         is Int -> {
                             if (key != VALUE_TO_SUM) {
                                 bundle.putInt(key, value)
@@ -101,25 +76,24 @@ class FacebookRemoteCommand : RemoteCommand {
          * @param value - the value to set on the Bundle
          * @param bundle - bundle to set key/value pairs that is used in tracking events
          */
-        fun <T> mapArrayToBundle(key: String, value: Array<T>, bundle: Bundle) {
-            if (value.count() > 0) {
+        private fun <T> mapArrayToBundle(key: String, value: Array<T>, bundle: Bundle) {
+            if (value.isNotEmpty()) {
                 when (value.first()) {
                     is Double -> {
-                        val doubleArray = (value as? ArrayList<Double>)?.toDoubleArray()
+                        val doubleArray = value.filterIsInstance<Double>().toDoubleArray()
                         bundle.putDoubleArray(key, doubleArray)
                     }
                     is Boolean -> {
-                        val booleanArray = (value.toList() as? ArrayList<Boolean>)?.toTypedArray()
-                            ?.toBooleanArray()
+                        val booleanArray = value.filterIsInstance<Boolean>().toBooleanArray()
                         bundle.putBooleanArray(key, booleanArray)
                     }
                     is Int -> {
-                        val intArray = (value as? ArrayList<Int>)?.toIntArray()
+                        val intArray = value.filterIsInstance<Int>().toIntArray()
                         bundle.putIntArray(key, intArray)
                     }
                     else -> {
-                        val stringArray = (value as? ArrayList<String>)
-                        bundle.putStringArrayList(key, stringArray)
+                        val stringArray = value.map { it.toString() }
+                        bundle.putStringArrayList(key, ArrayList(stringArray))
                     }
                 }
             }
@@ -188,7 +162,7 @@ class FacebookRemoteCommand : RemoteCommand {
                 }
                 Commands.SET_USER_ID -> {
                     val userId = payload.optString(User.USER_ID)
-                    userId?.let {
+                    userId.let {
                         if (it.isNotEmpty()) {
                             facebookInstance.setUserID(it)
                         } else {
@@ -284,7 +258,8 @@ class FacebookRemoteCommand : RemoteCommand {
                         if (contentId.isNotBlank()) {
                             logEvent(Commands.COMPLETED_TUTORIAL, 0.0, it)
                         } else {
-                            Log.e(TAG, "${Event.CONTENT_ID} $REQUIRED_KEY"
+                            Log.e(
+                                TAG, "${Event.CONTENT_ID} $REQUIRED_KEY"
                             )
                         }
                     }
@@ -296,7 +271,7 @@ class FacebookRemoteCommand : RemoteCommand {
                         if (valueToSum > 0.0) {
                             logEvent(Commands.INITIATED_CHECKOUT, valueToSum, it)
                         } else {
-                            Log.e(TAG, "${Event.VALUE_TO_SUM} $REQUIRED_KEY")
+                            Log.e(TAG, "$VALUE_TO_SUM $REQUIRED_KEY")
                         }
                     }
                 }
@@ -330,30 +305,26 @@ class FacebookRemoteCommand : RemoteCommand {
         return StandardEvents.standardEventNames[commandName] ?: commandName
     }
 
-    fun logEvent(command: String, valueToSum: Double, eventParameters: JSONObject? = null) {
+    private fun logEvent(command: String, valueToSum: Double, eventParameters: JSONObject? = null) {
         val bundle = Bundle()
         if (valueToSum > 0 && eventParameters != null) {
-            valueToSum?.let { sumValue ->
-                eventParameters?.let { parameters ->
-                    mapJsonToBundle(parameters, bundle)
-                }
+            valueToSum.let { sumValue ->
+                mapJsonToBundle(eventParameters, bundle)
                 facebookInstance.logEvent(command, sumValue, bundle)
             }
-        } else if (valueToSum > 0 && eventParameters == null) {
-            valueToSum?.let { sumValue ->
+        } else if (valueToSum > 0) {
+            valueToSum.let { sumValue ->
                 facebookInstance.logEvent(command, sumValue)
             }
         } else if (valueToSum == 0.0 && eventParameters != null) {
-            eventParameters?.let { eventParameters ->
-                mapJsonToBundle(eventParameters, bundle)
-            }
+            mapJsonToBundle(eventParameters, bundle)
             facebookInstance.logEvent(command, bundle)
         } else {
             facebookInstance.logEvent(command)
         }
     }
 
-    fun logPurchase(purchase: JSONObject) {
+    private fun logPurchase(purchase: JSONObject) {
         val amount = purchase.optDouble(Purchase.PURCHASE_AMOUNT) as? Double
         amount?.let {
             if (it.isNaN()) {
@@ -374,7 +345,7 @@ class FacebookRemoteCommand : RemoteCommand {
         }
     }
 
-    fun setUser(user: JSONObject) {
+    private fun setUser(user: JSONObject) {
         val email = user.optString(User.EMAIL)
         val firstName = user.optString(User.FIRST_NAME)
         val lastName = user.optString(User.LAST_NAME)
@@ -400,7 +371,7 @@ class FacebookRemoteCommand : RemoteCommand {
         )
     }
 
-    fun logProductItem(productItem: JSONObject) {
+    private fun logProductItem(productItem: JSONObject) {
         val productId = productItem.optString(ProductItemParameters.PRODUCT_ID)
         val productAvailability = productItem.optInt(ProductItemParameters.PRODUCT_AVAILABILITY)
         val productCondition = productItem.optInt(ProductItemParameters.PRODUCT_CONDITION)
@@ -424,10 +395,10 @@ class FacebookRemoteCommand : RemoteCommand {
         val bundle = Bundle()
         mapJsonToBundle(productParameters, bundle)
 
-        productAvailability?.let { productAvailability ->
-            val (availability) = guardLet(productAvailabilityFrom(productAvailability)) { return }
-            productCondition?.let { productCondition ->
-                val (condition) = guardLet(productConditionFrom(productCondition)) { return }
+        productAvailability.let { availabilityValue ->
+            val (availability) = guardLet(productAvailabilityFrom(availabilityValue)) { return }
+            productCondition.let { conditionValue ->
+                val (condition) = guardLet(productConditionFrom(conditionValue)) { return }
 
                 if (productId.isEmpty()
                     || productDescription.isEmpty()
@@ -459,10 +430,6 @@ class FacebookRemoteCommand : RemoteCommand {
         }
     }
 
-    fun enableAutoLogAppEvents(enable: Boolean) {
-        facebookInstance.enableAutoLogAppEvents(enable)
-    }
-
     fun splitCommands(payload: JSONObject): Array<String> {
         val command = payload.optString(Commands.COMMAND_KEY)
         return command.split(Commands.SEPARATOR.toRegex())
@@ -470,7 +437,7 @@ class FacebookRemoteCommand : RemoteCommand {
                 it.isEmpty()
             }
             .map {
-                it.trim().toLowerCase()
+                it.trim().lowercase()
             }
             .toTypedArray()
     }
@@ -511,11 +478,5 @@ inline fun <T : Any> guardLet(vararg elements: T?, closure: () -> Nothing): List
         elements.filterNotNull()
     } else {
         closure()
-    }
-}
-
-inline fun <T : Any> ifLet(vararg elements: T?, closure: (List<T>) -> Unit) {
-    if (elements.all { it != null }) {
-        closure(elements.filterNotNull())
     }
 }

--- a/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookRemoteCommand.kt
+++ b/facebook/src/main/java/com/tealium/remotecommands/facebook/FacebookRemoteCommand.kt
@@ -321,7 +321,7 @@ constructor(
         if (amount.isNaN()) {
             return
         }
-        val purchaseAmount = BigDecimal(amount)
+        val purchaseAmount = BigDecimal(amount.toString())
         val currencyString = purchase.optString(Purchase.PURCHASE_CURRENCY, "USD")
         val currency = getCurrency(currencyString) ?: return
         val parameters: JSONObject? = purchase.optJSONObject(Purchase.PURCHASE_PARAMETERS)
@@ -373,7 +373,7 @@ constructor(
         if (amount.isNaN()) {
             return
         }
-        val productPriceAmount = BigDecimal(amount)
+        val productPriceAmount = BigDecimal(amount.toString())
         val productGtin = productItem.optString(ProductItemParameters.PRODUCT_GTIN)
         val productMpn = productItem.optString(ProductItemParameters.PRODUCT_MPN)
         val productBrand = productItem.optString(ProductItemParameters.PRODUCT_BRAND)

--- a/facebook/src/test/java/com/tealium/remotecommands/facebook/FacebookRemoteCommandTest.kt
+++ b/facebook/src/test/java/com/tealium/remotecommands/facebook/FacebookRemoteCommandTest.kt
@@ -1,13 +1,6 @@
 package com.tealium.remotecommands.facebook
 
-import Advertiser
-import AutoInit
-import AutoLog
-import Commands
-import Event.VALUE_TO_SUM
-import Flush
-import Purchase
-import User
+import com.tealium.remotecommands.facebook.Event.VALUE_TO_SUM
 import android.os.Bundle
 import io.mockk.*
 import io.mockk.impl.annotations.InjectMockKs
@@ -324,10 +317,10 @@ class FacebookRemoteCommandTest {
         json.put("booleanArray", booleanArray)
         FacebookRemoteCommand.mapJsonToBundle(json, bundle)
 
-        assertEquals(bundle.getString("string"), "123")
-        assertEquals(bundle.getInt("int"), 123)
-        assertEquals(bundle.getDouble("double"), 0.123, 0.1)
-        assertEquals(bundle.getBoolean("boolean"), true)
+        assertEquals("123", bundle.getString("string"))
+        assertEquals(123, bundle.getInt("int"))
+        assertEquals(0.123, bundle.getDouble("double"), 0.001)
+        assertEquals(true, bundle.getBoolean("boolean"))
 
         bundle.getStringArray("stringArray")?.forEachIndexed { index, value ->
             assertEquals(stringArray[index], value)
@@ -336,7 +329,7 @@ class FacebookRemoteCommandTest {
             assertEquals(intArray[index], value)
         }
         bundle.getDoubleArray("doubleArray")?.forEachIndexed { index, value ->
-            assertEquals(doubleArray[index], value)
+            assertEquals(doubleArray[index], value, 0.001)
         }
         bundle.getBooleanArray("booleanArray")?.forEachIndexed { index, value ->
             assertEquals(booleanArray[index], value)

--- a/facebook/src/test/java/com/tealium/remotecommands/facebook/FacebookRemoteCommandTest.kt
+++ b/facebook/src/test/java/com/tealium/remotecommands/facebook/FacebookRemoteCommandTest.kt
@@ -13,6 +13,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.*
+import android.app.Application
+import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class FacebookRemoteCommandTest {
@@ -20,8 +22,10 @@ class FacebookRemoteCommandTest {
     @MockK
     lateinit var mockInstance: FacebookCommand
 
+    private val mockApplication = mockk<Application>(relaxed = true)
+    
     @InjectMockKs
-    var facebookRemoteCommand: FacebookRemoteCommand = FacebookRemoteCommand(null)
+    var facebookRemoteCommand: FacebookRemoteCommand = FacebookRemoteCommand(mockApplication)
 
     @Before
     fun setUp() {

--- a/facebook/src/test/java/com/tealium/remotecommands/facebook/FacebookRemoteCommandTest.kt
+++ b/facebook/src/test/java/com/tealium/remotecommands/facebook/FacebookRemoteCommandTest.kt
@@ -14,7 +14,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.*
 import android.app.Application
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class FacebookRemoteCommandTest {

--- a/facebook/src/test/java/com/tealium/remotecommands/facebook/LogProductItemTest.kt
+++ b/facebook/src/test/java/com/tealium/remotecommands/facebook/LogProductItemTest.kt
@@ -1,5 +1,6 @@
 package com.tealium.remotecommands.facebook
 
+import android.app.Application
 import com.facebook.appevents.AppEventsLogger
 import io.mockk.*
 import io.mockk.impl.annotations.InjectMockKs
@@ -17,8 +18,10 @@ class LogProductItemTest {
     @MockK
     lateinit var mockInstance: FacebookCommand
 
+    private val mockApplication = mockk<Application>(relaxed = true)
+    
     @InjectMockKs
-    var facebookRemoteCommand: FacebookRemoteCommand = FacebookRemoteCommand(null)
+    var facebookRemoteCommand: FacebookRemoteCommand = FacebookRemoteCommand(mockApplication)
 
     @Before
     fun setUp() {

--- a/facebook/src/test/java/com/tealium/remotecommands/facebook/LogProductItemTest.kt
+++ b/facebook/src/test/java/com/tealium/remotecommands/facebook/LogProductItemTest.kt
@@ -173,6 +173,34 @@ class LogProductItemTest {
         confirmVerified(mockInstance)
     }
 
+    @Test
+    fun logProductItemNotCalledWithInvalidCurrency() {
+        val payload = createProductItemJson()
+        payload.optJSONObject(Product.PRODUCT_ITEM)
+               .put(ProductItemParameters.PRODUCT_PRICE_CURRENCY, "INVALID")
+        
+        facebookRemoteCommand.parseCommands(arrayOf(Commands.LOG_PRODUCT_ITEM), payload)
+        
+        verify {
+            mockInstance wasNot Called
+        }
+        confirmVerified(mockInstance)
+    }
+
+    @Test
+    fun logProductItemNotCalledWithNanPriceAmount() {
+        val payload = createProductItemJson()
+        payload.optJSONObject(Product.PRODUCT_ITEM)
+               .put(ProductItemParameters.PRODUCT_PRICE_AMOUNT, Double.NaN)
+        
+        facebookRemoteCommand.parseCommands(arrayOf(Commands.LOG_PRODUCT_ITEM), payload)
+        
+        verify {
+            mockInstance wasNot Called
+        }
+        confirmVerified(mockInstance)
+    }
+
     private fun createProductItemJson(): JSONObject {
         val productItemParameters = JSONObject()
         productItemParameters.put(ProductItemParameters.PRODUCT_ID, "product_id")

--- a/facebook/src/test/java/com/tealium/remotecommands/facebook/LogProductItemTest.kt
+++ b/facebook/src/test/java/com/tealium/remotecommands/facebook/LogProductItemTest.kt
@@ -80,7 +80,7 @@ class LogProductItemTest {
     @Test
     fun logProductItemNotCalledWithoutProductIdKey() {
         val payload = createProductItemJson()
-        payload.optJSONObject(Product.PRODUCT_ITEM).remove(ProductItemParameters.PRODUCT_ID)
+        payload.optJSONObject(Product.PRODUCT_ITEM)?.remove(ProductItemParameters.PRODUCT_ID)
 
         facebookRemoteCommand.parseCommands(arrayOf(Commands.LOG_PRODUCT_ITEM), payload)
         verify {
@@ -92,7 +92,7 @@ class LogProductItemTest {
     @Test
     fun logProductItemNotCalledWithoutProductDescriptionKey() {
         val payload = createProductItemJson()
-        payload.optJSONObject(Product.PRODUCT_ITEM).remove(ProductItemParameters.PRODUCT_DESCRIPTION)
+        payload.optJSONObject(Product.PRODUCT_ITEM)?.remove(ProductItemParameters.PRODUCT_DESCRIPTION)
 
         facebookRemoteCommand.parseCommands(arrayOf(Commands.LOG_PRODUCT_ITEM), payload)
         verify {
@@ -104,7 +104,7 @@ class LogProductItemTest {
     @Test
     fun logProductItemNotCalledWithoutProductImageLinkKey() {
         val payload = createProductItemJson()
-        payload.optJSONObject(Product.PRODUCT_ITEM).remove(ProductItemParameters.PRODUCT_IMAGE_LINK)
+        payload.optJSONObject(Product.PRODUCT_ITEM)?.remove(ProductItemParameters.PRODUCT_IMAGE_LINK)
 
         facebookRemoteCommand.parseCommands(arrayOf(Commands.LOG_PRODUCT_ITEM), payload)
         verify {
@@ -116,7 +116,7 @@ class LogProductItemTest {
     @Test
     fun logProductItemNotCalledWithoutProductLinkKey() {
         val payload = createProductItemJson()
-        payload.optJSONObject(Product.PRODUCT_ITEM).remove(ProductItemParameters.PRODUCT_LINK)
+        payload.optJSONObject(Product.PRODUCT_ITEM)?.remove(ProductItemParameters.PRODUCT_LINK)
 
         facebookRemoteCommand.parseCommands(arrayOf(Commands.LOG_PRODUCT_ITEM), payload)
         verify {
@@ -128,7 +128,7 @@ class LogProductItemTest {
     @Test
     fun logProductItemNotCalledWithoutProductTitleKey() {
         val payload = createProductItemJson()
-        payload.optJSONObject(Product.PRODUCT_ITEM).remove(ProductItemParameters.PRODUCT_TITLE)
+        payload.optJSONObject(Product.PRODUCT_ITEM)?.remove(ProductItemParameters.PRODUCT_TITLE)
 
         facebookRemoteCommand.parseCommands(arrayOf(Commands.LOG_PRODUCT_ITEM), payload)
         verify {
@@ -140,7 +140,7 @@ class LogProductItemTest {
     @Test
     fun logProductItemNotCalledWithoutProductGtinKey() {
         val payload = createProductItemJson()
-        payload.optJSONObject(Product.PRODUCT_ITEM).remove(ProductItemParameters.PRODUCT_GTIN)
+        payload.optJSONObject(Product.PRODUCT_ITEM)?.remove(ProductItemParameters.PRODUCT_GTIN)
 
         facebookRemoteCommand.parseCommands(arrayOf(Commands.LOG_PRODUCT_ITEM), payload)
         verify {
@@ -152,7 +152,7 @@ class LogProductItemTest {
     @Test
     fun logProductItemNotCalledWithoutProductMpnKey() {
         val payload = createProductItemJson()
-        payload.optJSONObject(Product.PRODUCT_ITEM).remove(ProductItemParameters.PRODUCT_MPN)
+        payload.optJSONObject(Product.PRODUCT_ITEM)?.remove(ProductItemParameters.PRODUCT_MPN)
 
         facebookRemoteCommand.parseCommands(arrayOf(Commands.LOG_PRODUCT_ITEM), payload)
         verify {
@@ -164,37 +164,9 @@ class LogProductItemTest {
     @Test
     fun logProductItemNotCalledWithoutProductBrandKey() {
         val payload = createProductItemJson()
-        payload.optJSONObject(Product.PRODUCT_ITEM).remove(ProductItemParameters.PRODUCT_BRAND)
+        payload.optJSONObject(Product.PRODUCT_ITEM)?.remove(ProductItemParameters.PRODUCT_BRAND)
 
         facebookRemoteCommand.parseCommands(arrayOf(Commands.LOG_PRODUCT_ITEM), payload)
-        verify {
-            mockInstance wasNot Called
-        }
-        confirmVerified(mockInstance)
-    }
-
-    @Test
-    fun logProductItemNotCalledWithInvalidCurrency() {
-        val payload = createProductItemJson()
-        payload.optJSONObject(Product.PRODUCT_ITEM)
-               .put(ProductItemParameters.PRODUCT_PRICE_CURRENCY, "INVALID")
-        
-        facebookRemoteCommand.parseCommands(arrayOf(Commands.LOG_PRODUCT_ITEM), payload)
-        
-        verify {
-            mockInstance wasNot Called
-        }
-        confirmVerified(mockInstance)
-    }
-
-    @Test
-    fun logProductItemNotCalledWithNanPriceAmount() {
-        val payload = createProductItemJson()
-        payload.optJSONObject(Product.PRODUCT_ITEM)
-               .put(ProductItemParameters.PRODUCT_PRICE_AMOUNT, Double.NaN)
-        
-        facebookRemoteCommand.parseCommands(arrayOf(Commands.LOG_PRODUCT_ITEM), payload)
-        
         verify {
             mockInstance wasNot Called
         }

--- a/facebook/src/test/java/com/tealium/remotecommands/facebook/LogProductItemTest.kt
+++ b/facebook/src/test/java/com/tealium/remotecommands/facebook/LogProductItemTest.kt
@@ -1,10 +1,5 @@
 package com.tealium.remotecommands.facebook
 
-import Commands
-import Product
-import ProductAvailability
-import ProductCondition
-import ProductItemParameters
 import com.facebook.appevents.AppEventsLogger
 import io.mockk.*
 import io.mockk.impl.annotations.InjectMockKs

--- a/facebook/src/test/java/com/tealium/remotecommands/facebook/StandardEventTest.kt
+++ b/facebook/src/test/java/com/tealium/remotecommands/facebook/StandardEventTest.kt
@@ -112,4 +112,21 @@ class StandardEventTest {
         }
         confirmVerified(mockInstance)
     }
+
+    @Test
+    fun unknownEventNameUsedAsEventName() {
+        val customEventName = "myCustomEvent"
+        val result = facebookRemoteCommand.standardEvent(customEventName)
+        
+        Assert.assertEquals(customEventName, result)
+        
+        every { mockInstance.logEvent(customEventName) } just Runs
+        
+        facebookRemoteCommand.parseCommands(arrayOf(customEventName), JSONObject())
+        
+        verify {
+            mockInstance.logEvent(customEventName)
+        }
+        confirmVerified(mockInstance)
+    }
 }

--- a/facebook/src/test/java/com/tealium/remotecommands/facebook/StandardEventTest.kt
+++ b/facebook/src/test/java/com/tealium/remotecommands/facebook/StandardEventTest.kt
@@ -1,6 +1,5 @@
 package com.tealium.remotecommands.facebook
 
-import Event
 import android.os.Bundle
 import io.mockk.*
 import io.mockk.impl.annotations.InjectMockKs

--- a/facebook/src/test/java/com/tealium/remotecommands/facebook/StandardEventTest.kt
+++ b/facebook/src/test/java/com/tealium/remotecommands/facebook/StandardEventTest.kt
@@ -1,5 +1,6 @@
 package com.tealium.remotecommands.facebook
 
+import android.app.Application
 import android.os.Bundle
 import io.mockk.*
 import io.mockk.impl.annotations.InjectMockKs
@@ -16,8 +17,10 @@ class StandardEventTest {
     @MockK
     lateinit var mockInstance: FacebookCommand
 
+    private val mockApplication = mockk<Application>(relaxed = true)
+    
     @InjectMockKs
-    var facebookRemoteCommand: FacebookRemoteCommand = FacebookRemoteCommand(null)
+    var facebookRemoteCommand: FacebookRemoteCommand = FacebookRemoteCommand(mockApplication)
     
     @Before
     fun setUp() {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 14 16:59:34 GMT 2022
+#Wed May 07 16:29:32 CEST 2025
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed May 07 16:29:32 CEST 2025
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed May 07 16:29:32 CEST 2025
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Update Facebook SDK version to 18.0.3
- Update dependencies and configurations across multiple modules including Kotlin 1.9.3 and AGP 8.10.0
- Increase compileSdkVersion and targetSdkVersion from 31 to 33
- Refactor FacebookRemoteCommand class for improved structure and readability
- Enhance unit tests for FacebookRemoteCommand and LogProductItem
- Add client token metadata in AndroidManifest.xml and facebook.json
- Refactor FacebookCommand interface to accept clientToken parameter
- Update Tealium Facebook SDK version to 3.0.0